### PR TITLE
Automatic update of Microsoft.NET.Test.Sdk to 16.5.0-preview-20200110-02

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,3 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project>
   <ItemGroup>
     <PackageReference Update="CommandLineParser" Version="2.7.82" />
@@ -8,7 +9,7 @@
     <PackageReference Update="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="3.1.0" />
     <PackageReference Update="Microsoft.Extensions.Configuration.Json" Version="3.1.0" />
     <PackageReference Update="Microsoft.Extensions.DependencyInjection" Version="3.1.0" />
-    <PackageReference Update="Microsoft.NET.Test.Sdk" Version="16.5.0-preview-20200102-01" />
+    <PackageReference Update="Microsoft.NET.Test.Sdk" Version="16.5.0-preview-20200110-02" />
     <PackageReference Update="Moq" Version="4.13.1" />
     <PackageReference Update="Npgsql.EntityFrameworkCore.PostgreSQL" Version="3.1.0" />
     <PackageReference Update="octokit" Version="0.36.0" />


### PR DESCRIPTION
NuKeeper has generated a  update of `Microsoft.NET.Test.Sdk` to `16.5.0-preview-20200110-02` from `16.5.0-preview-20200102-01`
`Microsoft.NET.Test.Sdk 16.5.0-preview-20200110-02` was published at `2020-01-10T15:57:13Z`, 14 hours ago

1 project update:
Updated `Directory.Build.targets` to `Microsoft.NET.Test.Sdk` `16.5.0-preview-20200110-02` from `16.5.0-preview-20200102-01`

[Microsoft.NET.Test.Sdk 16.5.0-preview-20200110-02 on NuGet.org](https://www.nuget.org/packages/Microsoft.NET.Test.Sdk/16.5.0-preview-20200110-02)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
