### PR TITLE
Automatic update of Selenium.WebDriver to 4.0.0-alpha04

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,3 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project>
   <ItemGroup>
     <PackageReference Update="CommandLineParser" Version="2.7.82" />
@@ -13,7 +14,7 @@
     <PackageReference Update="Npgsql.EntityFrameworkCore.PostgreSQL" Version="3.1.0" />
     <PackageReference Update="octokit" Version="0.36.0" />
     <PackageReference Update="Selenium.Support" Version="4.0.0-alpha03" />
-    <PackageReference Update="Selenium.WebDriver" Version="4.0.0-alpha03" />
+    <PackageReference Update="Selenium.WebDriver" Version="4.0.0-alpha04" />
     <PackageReference Update="Selenium.WebDriver.ChromeDriver" Version="79.0.3945.3600" />
     <PackageReference Update="StyleCop.Analyzers" Version="1.2.0-beta.113" />
     <PackageReference Update="xunit" Version="2.4.1" />


### PR DESCRIPTION
NuKeeper has generated a  update of `Selenium.WebDriver` to `4.0.0-alpha04` from `4.0.0-alpha03`
`Selenium.WebDriver 4.0.0-alpha04` was published at `2020-01-11T00:35:04Z`, 6 hours ago

1 project update:
Updated `Directory.Build.targets` to `Selenium.WebDriver` `4.0.0-alpha04` from `4.0.0-alpha03`

[Selenium.WebDriver 4.0.0-alpha04 on NuGet.org](https://www.nuget.org/packages/Selenium.WebDriver/4.0.0-alpha04)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
