### PR TITLE
Bump GitBucket version to v4.39.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Utilities for GitBucket
 
 ## Requirements
 * [.NET 8.X SDK](https://www.microsoft.com/net/download/windows) ※Required only if you use dotnet tool version.
-* GitBucket 4.38.X+ (using PostgreSQL as backend DB)
+* GitBucket 4.39.X+ (using PostgreSQL as backend DB)
 
 ## Preparation
 ```cmd

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   gitbucket:
-    image: gitbucket/gitbucket:4.38.4
+    image: ghcr.io/gitbucket/gitbucket:4.39.0
     restart: always
     ports:
       - 8080:8080

--- a/src/GitBucket.Core/Models/CustomField.cs
+++ b/src/GitBucket.Core/Models/CustomField.cs
@@ -19,6 +19,8 @@ public partial class CustomField
 
     public bool EnableForPullRequests { get; set; }
 
+    public string? Constraints { get; set; }
+
     public virtual ICollection<IssueCustomField> IssueCustomFields { get; set; } = new List<IssueCustomField>();
 
     public virtual Repository Repository { get; set; } = null!;

--- a/src/GitBucket.Core/Models/GitBucketDbContext.cs
+++ b/src/GitBucket.Core/Models/GitBucketDbContext.cs
@@ -402,6 +402,9 @@ public partial class GitBucketDbContext : DbContext
             entity.Property(e => e.FieldId)
                 .ValueGeneratedOnAdd()
                 .HasColumnName("field_id");
+            entity.Property(e => e.Constraints)
+                .HasMaxLength(200)
+                .HasColumnName("constraints");
             entity.Property(e => e.EnableForIssues).HasColumnName("enable_for_issues");
             entity.Property(e => e.EnableForPullRequests).HasColumnName("enable_for_pull_requests");
             entity.Property(e => e.FieldName)


### PR DESCRIPTION
This pull request updates GitBucket to version 4.39.0, which includes improvements and bug fixes. The update also requires the use of PostgreSQL as the backend DB. Please review the changes and merge them into the main branch.